### PR TITLE
Bump Microsoft.Data.SqlClient from 1.0.19269.1 to 1.1.2

### DIFF
--- a/test/Elastic.Apm.PerfTests/Elastic.Apm.PerfTests.csproj
+++ b/test/Elastic.Apm.PerfTests/Elastic.Apm.PerfTests.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="0.12.0" />
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="1.0.19269.1" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="1.1.2" />
     <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Elastic.CommonSchema.BenchmarkDotNetExporter" Version="1.5.0" />
   </ItemGroup>

--- a/test/Elastic.Apm.SqlClient.Tests/Elastic.Apm.SqlClient.Tests.csproj
+++ b/test/Elastic.Apm.SqlClient.Tests/Elastic.Apm.SqlClient.Tests.csproj
@@ -14,7 +14,7 @@
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="5.6.0" />
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="1.1.1" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="1.1.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
     <PackageReference Include="coverlet.collector" Version="1.2.0">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
Bumps Microsoft.Data.SqlClient from 1.0.19269.1 to 1.1.2.