### PR TITLE
Bump SpecFlow.xUnit from 3.1.86 to 3.1.97

### DIFF
--- a/test/Elastic.Apm.Feature.Tests/Elastic.Apm.Feature.Tests.csproj
+++ b/test/Elastic.Apm.Feature.Tests/Elastic.Apm.Feature.Tests.csproj
@@ -12,7 +12,7 @@
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="SpecFlow.Tools.MsBuild.Generation" Version="3.1.86" />
-        <PackageReference Include="SpecFlow.xUnit" Version="3.1.86" />
+        <PackageReference Include="SpecFlow.xUnit" Version="3.1.97" />
         <PackageReference Include="xunit" Version="2.4.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
     </ItemGroup>


### PR DESCRIPTION
Bumps SpecFlow.xUnit from 3.1.86 to 3.1.97.